### PR TITLE
inclusive check for `matcherForMinimumVisiblePercent`

### DIFF
--- a/EarlGrey/Matcher/GREYMatchers.m
+++ b/EarlGrey/Matcher/GREYMatchers.m
@@ -224,7 +224,7 @@ static const double kElementSufficientlyVisiblePercentage = 0.75;
   GREYFatalAssertWithMessage(percent >= 0.0f && percent <= 1.0f,
                              @"Percent %f must be in the range [0,1]", percent);
   MatchesBlock matches = ^BOOL(UIView *element) {
-    return [GREYVisibilityChecker percentVisibleAreaOfElement:element] > percent;
+    return [GREYVisibilityChecker percentVisibleAreaOfElement:element] >= percent;
   };
   DescribeToBlock describe = ^void(id<GREYDescription> description) {
     [description appendText:


### PR DESCRIPTION
This fix was added to earlgrey2
(https://github.com/google/EarlGrey/pull/997) but is not available in
wix's fork.

This PR is a complementary for https://github.com/wix/Detox/pull/1720
and should allow expecting 'to be visible at least X' and include X in
the range.